### PR TITLE
Season 2 Reloaded

### DIFF
--- a/src/data/camouflages.js
+++ b/src/data/camouflages.js
@@ -65,18 +65,18 @@ export default [
     name: 'Predatory Ambition',
     requirements: {
       atomic: {
-        'Assault Rifles': { default: 'Get 50 MultiKills' },
-        'Handguns': { default: 'Get 50 MultiKills' },
+        'Assault Rifles': { default: 'Get 50 Multikills' },
+        'Handguns': { default: 'Get 50 Multikills' },
         'Launchers': {
           default: 'Destroy 50 Ground Killstreaks or Field Upgrades',
           'MK11 Launcher': 'Get 50 Longshot Kills'
         },
-        'Light Machine Guns': { default: 'Get 50 MultiKills' },
-        'Marksman Rifles': { default: 'Get 50 MultiKills' },
+        'Light Machine Guns': { default: 'Get 50 Multikills' },
+        'Marksman Rifles': { default: 'Get 50 Multikills' },
         'Melee': { default: 'Get 30 Slide Kills' },
-        'Shotguns': { default: 'Get 50 MultiKills' },
-        'Sniper Rifles': { default: 'Get 50 MultiKills' },
-        'Submachine Guns': { default: 'Get 50 MultiKills' }
+        'Shotguns': { default: 'Get 50 Multikills' },
+        'Sniper Rifles': { default: 'Get 50 Multikills' },
+        'Submachine Guns': { default: 'Get 50 Multikills' }
       },
       aether: {
         'Assault Rifles': { default: 'In Zombies, get 4000 Pack-a-Punched Eliminations' },

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -1,6 +1,6 @@
 import { defaultProgress } from '../defaults'
 
-const weapons = ['MP-40', 'Sten', 'M1928', 'Owen Gun', 'Type 100', 'PPSh-41', 'Welgun']
+const weapons = ['MP-40', 'Sten', 'M1928', 'Owen Gun', 'Type 100', 'PPSh-41', 'Welgun', 'Armaguerra 43']
 const original = ['MP-40', 'Sten', 'M1928', 'Owen Gun', 'Type 100', 'PPSh-41']
 
 export default weapons.map(weapon => ({


### PR DESCRIPTION
### Changelog

**- Added Season 2 Reloaded Weapon**
- Submachine Gun: Armaguerra 43

**Fixes**
- Changed "MultiKills" to "Multikills" for parity with Vanguard.